### PR TITLE
Replaced EOS with CORE_SYMBOL

### DIFF
--- a/signupeoseos.cpp
+++ b/signupeoseos.cpp
@@ -8,7 +8,7 @@ void signupeoseos::transfer(account_name from, account_name to, asset quantity, 
     if (from == _self || to != _self) {
         return;
     }
-    eosio_assert(quantity.symbol == string_to_symbol(4, "EOS"), "signupeoseos only accepts EOS for signup eos account");
+    eosio_assert(quantity.symbol == CORE_SYMBOL, "signupeoseos only accepts CORE for signup eos account");
     eosio_assert(quantity.is_valid(), "Invalid token transfer");
     eosio_assert(quantity.amount > 0, "Quantity must be positive");
 
@@ -44,10 +44,10 @@ void signupeoseos::transfer(account_name from, account_name to, asset quantity, 
     array<unsigned char,33> pubkey_data;
     copy_n(vch.begin(), 33, pubkey_data.begin());
 
-    asset stake_net(1000, S(4, EOS));
-    asset stake_cpu(1000, S(4, EOS));
+    asset stake_net(1000, CORE_SYMBOL);
+    asset stake_cpu(1000, CORE_SYMBOL);
     asset buy_ram = quantity - stake_net - stake_cpu;
-    eosio_assert(buy_ram.amount > 0, "Not enough eos to buy ram");
+    eosio_assert(buy_ram.amount > 0, "Not enough balance to buy ram");
 
     signup_public_key pubkey = {
         .type = 0,

--- a/signupeoseos.hpp
+++ b/signupeoseos.hpp
@@ -6,6 +6,7 @@
 #include <eosiolib/asset.hpp>
 #include <eosiolib/types.hpp>
 #include <eosiolib/action.hpp>
+#include <eosiolib/symbol.hpp>
 
 using namespace eosio;
 using namespace std;


### PR DESCRIPTION
The local testnet node is compiled with `SYS` as the core symbol by default. Replacing the hard-coded `EOS` with the macro `CORE_SYMBOL` makes the contract directly deployable in these environments.